### PR TITLE
Feature/norne reservoir fix

### DIFF
--- a/intersected_cell.cpp
+++ b/intersected_cell.cpp
@@ -21,58 +21,58 @@
 #include "intersected_cell.h"
 
 namespace Reservoir {
-    namespace WellIndexCalculation {
+namespace WellIndexCalculation {
 
-        std::vector<Vector3d> IntersectedCell::points() const {
-            return std::vector<Vector3d>({entry_point_, exit_point_});
-        }
+std::vector<Vector3d> IntersectedCell::points() const {
+    return std::vector<Vector3d>({entry_point_, exit_point_});
+}
 
-        Vector3d IntersectedCell::xvec() const {
-            return corners()[5] - corners()[4];
-        }
+Vector3d IntersectedCell::xvec() const {
+    return corners()[5] - corners()[4];
+}
 
-        Vector3d IntersectedCell::yvec() const {
-            return corners()[6] - corners()[4];
-        }
+Vector3d IntersectedCell::yvec() const {
+    return corners()[6] - corners()[4];
+}
 
-        Vector3d IntersectedCell::zvec() const {
-            return corners()[0] - corners()[4];
-        }
+Vector3d IntersectedCell::zvec() const {
+    return corners()[0] - corners()[4];
+}
 
-        double IntersectedCell::dx() const {
-            return xvec().norm();
-        }
+double IntersectedCell::dx() const {
+    return xvec().norm();
+}
 
-        double IntersectedCell::dy() const {
-            return yvec().norm();
-        }
+double IntersectedCell::dy() const {
+    return yvec().norm();
+}
 
-        double IntersectedCell::dz() const {
-            return zvec().norm();
-        }
+double IntersectedCell::dz() const {
+    return zvec().norm();
+}
 
-        const Vector3d &IntersectedCell::entry_point() const {
-            return entry_point_;
-        }
+const Vector3d &IntersectedCell::entry_point() const {
+    return entry_point_;
+}
 
-        void IntersectedCell::set_entry_point(const Vector3d &entry_point) {
-            entry_point_ = entry_point;
-        }
+void IntersectedCell::set_entry_point(const Vector3d &entry_point) {
+    entry_point_ = entry_point;
+}
 
-        const Vector3d &IntersectedCell::exit_point() const {
-            return exit_point_;
-        }
+const Vector3d &IntersectedCell::exit_point() const {
+    return exit_point_;
+}
 
-        void IntersectedCell::set_exit_point(const Vector3d &exit_point) {
-            exit_point_ = exit_point;
-        }
+void IntersectedCell::set_exit_point(const Vector3d &exit_point) {
+    exit_point_ = exit_point;
+}
 
-        double IntersectedCell::well_index() const {
-            return well_index_;
-        }
+double IntersectedCell::well_index() const {
+    return well_index_;
+}
 
-        void IntersectedCell::set_well_index(double well_index) {
-            well_index_ = well_index;
-        }
-    }
+void IntersectedCell::set_well_index(double well_index) {
+    well_index_ = well_index;
+}
+}
 }

--- a/intersected_cell.h
+++ b/intersected_cell.h
@@ -1,6 +1,6 @@
 /******************************************************************************
    Copyright (C) 2015-2016 Hilmar M. Magnusson <hilmarmag@gmail.com>
-   Modified by Einar J.M. Baumann (2016) <einar.baumann@gmail.com>
+   Modified by Einar J.M. Baumann (2016-2017) <einar.baumann@gmail.com>
 
    This file and the WellIndexCalculator as a whole is part of the
    FieldOpt project. However, unlike the rest of FieldOpt, the
@@ -29,39 +29,39 @@
 
 namespace Reservoir {
 namespace WellIndexCalculation {
-    using namespace Eigen;
-    /*!
-     * \brief The IntersectedCell struct holds
-     * information about an intersected cell.
-     */
-    class IntersectedCell : public Grid::Cell {
-    public:
-        IntersectedCell() {}
-        IntersectedCell(const Grid::Cell &cell) : Grid::Cell(cell) {};
+using namespace Eigen;
+/*!
+ * \brief The IntersectedCell struct holds
+ * information about an intersected cell.
+ */
+class IntersectedCell : public Grid::Cell {
+ public:
+  IntersectedCell() {}
+  IntersectedCell(const Grid::Cell &cell) : Grid::Cell(cell) {}
 
-        std::vector<Vector3d> points() const;
+  std::vector<Vector3d> points() const;
 
-        Vector3d xvec() const;
-        Vector3d yvec() const;
-        Vector3d zvec() const;
-        double dx() const;
-        double dy() const;
-        double dz() const;
+  Vector3d xvec() const;
+  Vector3d yvec() const;
+  Vector3d zvec() const;
+  double dx() const;
+  double dy() const;
+  double dz() const;
 
-        const Vector3d & entry_point() const;
-        const Vector3d & exit_point() const;
+  const Vector3d & entry_point() const;
+  const Vector3d & exit_point() const;
 
-        void set_entry_point(const Vector3d &entry_point);
-        void set_exit_point(const Vector3d &exit_point);
+  void set_entry_point(const Vector3d &entry_point);
+  void set_exit_point(const Vector3d &exit_point);
 
-        double well_index() const;
-        void set_well_index(double well_index);
+  double well_index() const;
+  void set_well_index(double well_index);
 
-    private:
-        Vector3d entry_point_;
-        Vector3d exit_point_;
-        double well_index_;
-    };
+ private:
+  Vector3d entry_point_;
+  Vector3d exit_point_;
+  double well_index_;
+};
 }
 }
 

--- a/tests/test_single_cell_wellindex.cpp
+++ b/tests/test_single_cell_wellindex.cpp
@@ -77,6 +77,7 @@ TEST_F(SingleCellWellIndexTest, WellIndexValueWithQVector_test) {
     Eigen::Vector3d end_point = Eigen::Vector3d(well_end_x,well_end_y, well_end_z);
 
     auto icell = IntersectedCell(cell_1);
+    grid_->FillCellProperties(icell);
     icell.set_entry_point(start_point);
     icell.set_exit_point(end_point);
 
@@ -112,6 +113,7 @@ TEST_F(SingleCellWellIndexTest, vertical_well_index_test) {
     Eigen::Vector3d end_point= Eigen::Vector3d(well_end_x,well_end_y, well_end_z);
 
     Reservoir::WellIndexCalculation::IntersectedCell icell(cell_1);
+    grid_->FillCellProperties(icell);
     icell.set_entry_point(start_point);
     icell.set_exit_point(end_point);
 

--- a/tests/test_single_cell_wellindex.cpp
+++ b/tests/test_single_cell_wellindex.cpp
@@ -86,12 +86,9 @@ TEST_F(SingleCellWellIndexTest, WellIndexValueWithQVector_test) {
     double wi = wic.compute_well_index(icell);
     /* 0.555602 is the expected well transmisibility factor aka. well index.
      * For now this value is read directly from eclipse output file:
-     * Expect value within delta percent
+     * Expect value within 0.001
      */
-    double delta = 0.001;
-    double delta_percent =1+(delta/100);
-    EXPECT_TRUE( wi < 0.555602*(delta_percent));
-    EXPECT_TRUE( wi > 0.555602/(delta_percent));
+    EXPECT_NEAR(wi, 0.555602, 0.001);
 }
 
 TEST_F(SingleCellWellIndexTest, vertical_well_index_test) {

--- a/wellindexcalculator.cpp
+++ b/wellindexcalculator.cpp
@@ -55,6 +55,7 @@ vector<IntersectedCell> WellIndexCalculator::cells_intersected() {
     intersected_cells.push_back(
         IntersectedCell( grid_->GetCellEnvelopingPoint(heel_) )
     );
+    grid_->FillCellProperties(intersected_cells[0]); // Get poro and perm data
     intersected_cells[0].set_entry_point(heel_);
 
     // Find the toe cell -- removed by OV; why?
@@ -84,6 +85,7 @@ vector<IntersectedCell> WellIndexCalculator::cells_intersected() {
         intersected_cells.push_back(
             IntersectedCell(grid_->GetCellEnvelopingPoint( move_exit_epsilon ))
         );
+        grid_->FillCellProperties(intersected_cells.back()); // Get poro and perm data
         // The entry point of each cell is the exit point of the previous cell
         intersected_cells.back().set_entry_point(exit_point);
 


### PR DESCRIPTION
The only significant changes here are in `wellindexcalculator.cpp`. This file was updated tp use the new `FillCellProperties` (the corresponding pull request in the FieldOpt repo) function for the intersected cells.

See PetroleumCyberneticsGroup/FieldOpt#62